### PR TITLE
Bumps, 4.0+ and some "improved" behaviours

### DIFF
--- a/render_thumbnails.py
+++ b/render_thumbnails.py
@@ -49,7 +49,7 @@ class RenderAssetsThumbnail(bpy.types.Operator):
                 self.select_all_objects_in_collection(collection)
                 return collection
 
-    # Custom context is needed as of 3.0+ to invoke the operator here
+    # Custom context is needed as of 4.0+ to invoke the operator here
     def update_thumbnail(self, context, asset: bpy.types.FileSelectEntry, location: str) -> None:
         with context.temp_override(id=asset.local_id):
             bpy.ops.ed.lib_id_load_custom_preview(


### PR DESCRIPTION
I updated API calls to comply with bpy's new(er) AssetRepresentation object, resolving issue #3 
#

Version bumped and confirmed working in Blender 4.4. 

Also, while I was here, I made two notable changes:
- The operator will keep track of the current .blend's configured image file type and compositor setting, so that it can force renders to occur in .PNG with "Use Nodes" disabled.
- The sub-directory named after the object's collection will now include the name of the blend file that collection originates from. This change prevents the addon from overwriting thumbnails from different blend files in the same asset directory. (I have a lot of assets just named by number - '1', '2'... etc - in different blend files)

